### PR TITLE
Bug-fix: when no custom transition guard exists, default to permitting the transition

### DIFF
--- a/SwiftStateMachine/SwiftStateMachine.swift
+++ b/SwiftStateMachine/SwiftStateMachine.swift
@@ -122,9 +122,9 @@ public class StateMachine {
     public func canPerformTransition(transitionLabel:TransitionLabel) -> Bool {
         if let transition = self.state.transitions[transitionLabel] {
             if let guard = transition.guard {
-                if guard(state:self.state) == true {
-                    return true
-                }
+                return guard(state:self.state)
+            } else {
+                return true
             }
         }
         return false


### PR DESCRIPTION
It looks like the `Transition.guard` property is intended as a hook for custom complex overrides about when a transition is permitted.

The code, as currently written will always fail in `canPerformTransition` if no custom transition guard is defined. I defined the case where no transition guard is implemented to default to permit the transition.

When I make the change in this PR, the example code in the Playground starts transitioning through states and logging necessary state errors/warnings. Whereas, before, the StateMachine stayed in a locked state.