### PR TITLE
StateMachine Definition File Support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -128,17 +128,35 @@ The "turnstile" definition state diagram looks like:
 
 ## State Machine Definition Domain Specific Language EBNF
 
-    letter = "A" | "B" | "C" | "D" | "E" | "F" | "G"
-           | "H" | "I" | "J" | "K" | "L" | "M" | "N"
-           | "O" | "P" | "Q" | "R" | "S" | "T" | "U"
-           | "V" | "W" | "X" | "Y" | "Z" ;
-
-    identifier = letter , { letter } ;
+    identifier = identifier_character { identifier_character } ;
 
     state_label = identifier ;
-
     transition_label = identifier ;
 
     definition = state_label , "->" , state_label , "(" , transition_label, ")"
 
+    valid_lines = definition {";"} | commented_line | blank_line
+
+    (* parse the valid_lines in the file, but generate a list of definitions by filtering *)
     definitions = definition { ";" , definition }
+
+    (* Below this point is the boilerplate of EBNF *)
+    identifier_character = letter | digit | safe_symbol ;
+
+    commented_line = comment_symbol , all_characters* , NEWLINE ;
+
+    letter = "A" | "B" | "C" | "D" | "E" | "F" | "G"
+           | "H" | "I" | "J" | "K" | "L" | "M" | "N"
+           | "O" | "P" | "Q" | "R" | "S" | "T" | "U"
+           | "V" | "W" | "X" | "Y" | "Z" | "a" | "b"
+           | "c" | "d" | "e" | "f" | "g" | "h" | "i"
+           | "j" | "k" | "l" | "m" | "n" | "o" | "p"
+           | "q" | "r" | "s" | "t" | "u" | "v" | "w"
+           | "x" | "y" | "z" ;
+    digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
+    safe_symbol = "." | "-" | "_" ;
+    whitespace = ? all whitespace characters ? ;
+	all_characters = ? all visible characters ? ;
+    comment_symbol = "#" ;
+
+    blank_line = whitespace* , NEWLINE ;

--- a/SwiftStateMachine/SwiftStateMachine.swift
+++ b/SwiftStateMachine/SwiftStateMachine.swift
@@ -245,6 +245,29 @@ public extension StateMachine.Definition {
     }
 }
 
+// MARK: Equatable
+
+// Note: this only tests if the Definitions are structurally the same.
+// It does not test the gating logic is bound to the same block, for example.
+
+extension StateMachine.Definition : Equatable {}
+extension StateMachine.State : Equatable {}
+extension StateMachine.Transition : Equatable {}
+
+public func ==(lhs: StateMachine.Definition, rhs: StateMachine.Definition) -> Bool {
+	return lhs.initialState.label == rhs.initialState.label
+		&& lhs.states == rhs.states
+}
+public func ==(lhs: StateMachine.State, rhs: StateMachine.State) -> Bool {
+	return lhs.label == rhs.label
+		&& lhs.transitions == rhs.transitions
+}
+public func ==(lhs: StateMachine.Transition, rhs: StateMachine.Transition) -> Bool {
+	return lhs.label == rhs.label
+		// Test the labels for equality, because we don't want to infinitely recurse testing transitions!
+		&& lhs.state.label == rhs.state.label && lhs.nextState.label == rhs.nextState.label
+}
+
 // MARK: Export
 
 public extension StateMachine.Definition {

--- a/SwiftStateMachine/SwiftStateMachine.swift
+++ b/SwiftStateMachine/SwiftStateMachine.swift
@@ -202,9 +202,12 @@ public extension StateMachine.Definition {
 	 - see: README.markdown for a full EBNF grammar.
 	 */
     func processDefinitionFormats(string: String) throws {
-		let definitionsList = string.componentsSeparatedByCharactersInSet(NSCharacterSet.newlineCharacterSet()).filter { (line) -> Bool in
-			// Remove all commented-out lines & whitespace only lines
-			return !(line.hasPrefix("#") || line.stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceCharacterSet()).characters.count == 0)
+		let definitionsList = string
+			.stringByReplacingOccurrencesOfString("#", withString: "\n#") // Allow comments to be on the same line as a definition
+			.componentsSeparatedByCharactersInSet(NSCharacterSet.newlineCharacterSet())
+			.filter { (line) -> Bool in
+				// Remove all commented-out lines & whitespace only lines
+				return !(line.hasPrefix("#") || line.stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceCharacterSet()).characters.count == 0)
 			}
 			.joinWithSeparator("") // Into a flat string of definitions, allowing definitions to span multiple lines
 			.componentsSeparatedByString(";") // Split into potential definitions

--- a/Table.playground/Contents.swift
+++ b/Table.playground/Contents.swift
@@ -11,7 +11,20 @@ try! machineDefinition.processDefinitionFormats("locked -> locked (push)")
 try! machineDefinition.processDefinitionFormats("locked -> unlocked (coin)")
 try! machineDefinition.processDefinitionFormats("unlocked -> locked (push)")
 try! machineDefinition.processDefinitionFormats("unlocked -> unlocked (coin)")
-machineDefinition.initialState = machineDefinition.states["locked"]
+
+// Demonstrate another way of expressing the above state machine (useful for reading from a file)
+var stateMachineAsSingleString = "# Coin machine\n" + // Commented line
+	"locked -> locked (push);" +
+	"locked -> unlocked (coin);\n" +
+	"\n" +	// Blank line
+	"unlocked -> locked (push);\n" +
+	"unlocked -> unlocked (coin);"
+
+// Try to create an identical definition from a single multi-line string
+var multiDefinition = StateMachine.Definition()
+try! multiDefinition.processDefinitionFormats(stateMachineAsSingleString)
+// Assert they're equivalent
+assert(machineDefinition == multiDefinition)
 
 machineDefinition.states["unlocked"]!.transitions["coin"]!.action = { t in print("#### Stile already unlocked. Coin rejected.") }
 machineDefinition.states["locked"]!.transitions["push"]!.action = { t in print("#### Stile locked. Try putting a coin in.") }

--- a/Table.playground/Contents.swift
+++ b/Table.playground/Contents.swift
@@ -13,9 +13,10 @@ try! machineDefinition.processDefinitionFormats("unlocked -> locked (push)")
 try! machineDefinition.processDefinitionFormats("unlocked -> unlocked (coin)")
 
 // Demonstrate another way of expressing the above state machine (useful for reading from a file)
-var stateMachineAsSingleString = "# Coin machine\n" + // Commented line
+var stateMachineAsSingleString =
+	"# Coin machine\n" + // Commented line
 	"locked -> locked (push);" +
-	"locked -> unlocked (coin);\n" +
+	"locked -> unlocked (coin); # trailing comment\n" +
 	"\n" +	// Blank line
 	"unlocked -> locked (push);\n" +
 	"unlocked -> unlocked (coin);"


### PR DESCRIPTION
Update the EBNF & DSL parser to:
1. allow some symbols (`_.-`) & numerals in identifiers.
2. allow comments and blank lines. (Comments can be on their own line, or they can trail a definition)
3. allow the last definition to terminate with a semi-colon.

Incidentally update the Readme with a slightly more accurate grammar, and implement Equatable so Definitions can be lightly compared. (Example in Table.playground)

These changes make it easier to specify a StateMachine in a separate file that you can add documentation to.