### PR TITLE
Always quote our graphViz labels

### DIFF
--- a/SwiftStateMachine/SwiftStateMachine.swift
+++ b/SwiftStateMachine/SwiftStateMachine.swift
@@ -289,14 +289,14 @@ public extension StateMachine.Definition {
         dot += "\tstart [label=\"\", shape=circle, style=filled, color=black, height=0.25, width=0.25]\n"
 
         for state in states.values {
-            dot += "\t\(state.label) [label=\"\(state.label)\"]\n"
+            dot += "\t\"\(state.label)\" [label=\"\(state.label)\"]\n"
         }
 
-        dot += "\tstart -> \(initialState.label)\n"
+        dot += "\tstart -> \"\(initialState.label)\"\n"
 
         for state in states.values {
             for transition in state.transitions.values {
-                dot += "\t\(state.label) -> \(transition.nextState.label) [label=\"\(transition.label)\"]\n"
+                dot += "\t\"\(state.label)\" -> \"\(transition.nextState.label)\" [label=\"\(transition.label)\"]\n"
             }
         }
 


### PR DESCRIPTION
Fixes bug when labels have symbols not supported as bare graphViz identifiers.

Repro:
1. create a state-label with a dot in the name `.`
2. generate graph-viz representation to a file.
3. run `$ dot` on this file to attempt to generate a png.
4. Notice stderror complaining about `Error: file.dot: syntax error in line 27 near '.'` (where line 27 corresponds to a line that references a label containing a dot `.` or other symbol.